### PR TITLE
Allow resource limiting via systemd slice

### DIFF
--- a/app/util/docker_actions.py
+++ b/app/util/docker_actions.py
@@ -65,6 +65,7 @@ def compileOD(codeText: str, compile_args: list, timeout: int = 30) -> dict:
         network_disabled=True,
         volumes=[f"{randomDir}:/app/code:ro"],
         command=compile_args,
+        cgroup_parent="od_compiler.slice",
     )
 
     stop_time = 3


### PR DESCRIPTION
This allows us to configure CPU/memory limits via od_compiler.slice on systemd.