### PR TITLE
Removes the strict character limit on compiler/run log outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "od-compiler"
-version = "0.1.4"
+version = "0.2.0"
 description = "OpenDream compiler listener"
 authors = ["Crossedfall <ping@crossedfall.io>"]
 maintainers = ["Crossedfall <ping@crossedfall.io>"]

--- a/src/od_compiler/util/utilities.py
+++ b/src/od_compiler/util/utilities.py
@@ -57,9 +57,6 @@ def splitLogs(logs: str, killed: bool = False) -> dict[str, str]:
     compile_log = matches.group(1)
     run_log = matches.group(2)
 
-    compile_log = (compile_log[:5000] + "...") if len(compile_log) > 5000 else compile_log
-    run_log = (run_log[:5000] + "...") if len(run_log) > 5000 else run_log
-
     parsed["compiler"] = compile_log
     parsed["server"] = run_log
 

--- a/src/od_compiler/util/utilities.py
+++ b/src/od_compiler/util/utilities.py
@@ -57,8 +57,8 @@ def splitLogs(logs: str, killed: bool = False) -> dict[str, str]:
     compile_log = matches.group(1)
     run_log = matches.group(2)
 
-    compile_log = (compile_log[:1200] + "...") if len(compile_log) > 1200 else compile_log
-    run_log = (run_log[:1200] + "...") if len(run_log) > 1200 else run_log
+    compile_log = (compile_log[:5000] + "...") if len(compile_log) > 5000 else compile_log
+    run_log = (run_log[:5000] + "...") if len(run_log) > 5000 else run_log
 
     parsed["compiler"] = compile_log
     parsed["server"] = run_log


### PR DESCRIPTION
Instead of truncating the log outputs on the compiler server, we'll send the full outputs and parse them on the cog instead. This should afford a bit more flexibility at the cost of having to transit slightly more data between the two.

This will also resolve the current issue where the cog is unable to detect the ODC stanza following changes to the OpenDream startup sequence.

Partner PR: 

- https://github.com/OpenDreamProject/od-cogs/pull/2