### PR TITLE
Adds support for different build configurations

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,8 +4,10 @@ WORKDIR /opendream
 
 COPY ./OpenDream/ .
 
-RUN dotnet build OpenDreamServer && \
-	dotnet build DMCompiler && \
+ARG BULD_CONFIG=Release
+
+RUN dotnet build OpenDreamServer --configuration ${BULD_CONFIG} && \
+	dotnet build DMCompiler --configuration ${BULD_CONFIG} && \
     ln -s /opendream/bin/DMCompiler/DMCompiler /usr/bin/ && \
     ln -s /opendream/bin/Content.Server/OpenDreamServer /usr/bin
 

--- a/src/od_compiler/__init__.py
+++ b/src/od_compiler/__init__.py
@@ -30,9 +30,9 @@ def startCompile() -> Response:
     compile_logger.debug(f"Request incoming containing: {posted_data}")
     if "code_to_compile" in posted_data:
         compile_logger.info("Request received. Attempting to compile...")
-        build_args = posted_data["build_arguments"] if "build_arguments" in posted_data else "Release"
+        build_args = posted_data["build_config"] if "build_config" in posted_data else "Release"
         compile_args = posted_data["extra_arguments"] if "extra_arguments" in posted_data else None
-        return jsonify(compileOD(posted_data["code_to_compile"], compile_args=compile_args, build_args=build_args))
+        return jsonify(compileOD(posted_data["code_to_compile"], compile_args=compile_args, build_config=build_args))
     else:
         compile_logger.warning(f"Bad request received:\n{request.get_json()}")
         return abort(400)

--- a/src/od_compiler/__init__.py
+++ b/src/od_compiler/__init__.py
@@ -30,8 +30,9 @@ def startCompile() -> Response:
     compile_logger.debug(f"Request incoming containing: {posted_data}")
     if "code_to_compile" in posted_data:
         compile_logger.info("Request received. Attempting to compile...")
-        args = posted_data["extra_arguments"] if "extra_arguments" in posted_data else None
-        return jsonify(compileOD(posted_data["code_to_compile"], compile_args=args))
+        build_args = posted_data["build_arguments"] if "build_arguments" in posted_data else "Release"
+        compile_args = posted_data["extra_arguments"] if "extra_arguments" in posted_data else None
+        return jsonify(compileOD(posted_data["code_to_compile"], compile_args=compile_args, build_args=build_args))
     else:
         compile_logger.warning(f"Bad request received:\n{request.get_json()}")
         return abort(400)

--- a/src/od_compiler/util/docker_actions.py
+++ b/src/od_compiler/util/docker_actions.py
@@ -16,7 +16,7 @@ from docker.errors import BuildError
 client = docker_from_env()
 
 
-def updateBuildImage(build_Config: str) -> None:
+def updateBuildImage(build_config: str) -> None:
     """
     Update OpenDream and then use Docker's build context to see if we need to build a new image.
     """
@@ -35,13 +35,13 @@ def updateBuildImage(build_Config: str) -> None:
         pull=True,
         encoding="gzip",
         tag="od-compiler:latest",
-        buildargs={"BULD_CONFIG": build_Config},
+        buildargs={"BULD_CONFIG": build_config},
     )
     client.images.prune(filters={"dangling": True})
 
 
 def compileOD(
-    codeText: str, compile_args: list[str], build_args: str = "Release", timeout: int = 30
+    codeText: str, compile_args: list[str], build_config: str = "Release", timeout: int = 30
 ) -> dict[str, object]:
     """
     Create an OpenDream docker container to compile and run arbitrary code.
@@ -53,7 +53,7 @@ def compileOD(
     timeout: Maximum duration a container is allowed to run for
     """
     try:
-        updateBuildImage(build_Config=build_args)
+        updateBuildImage(build_config=build_config)
     except BuildError as e:
         results = {"build_error": True, "exception": str(e)}
         return results

--- a/src/od_compiler/util/docker_actions.py
+++ b/src/od_compiler/util/docker_actions.py
@@ -16,7 +16,7 @@ from docker.errors import BuildError
 client = docker_from_env()
 
 
-def updateBuildImage() -> None:
+def updateBuildImage(build_Config: str) -> None:
     """
     Update OpenDream and then use Docker's build context to see if we need to build a new image.
     """
@@ -35,11 +35,14 @@ def updateBuildImage() -> None:
         pull=True,
         encoding="gzip",
         tag="od-compiler:latest",
+        buildargs={"BULD_CONFIG": build_Config},
     )
     client.images.prune(filters={"dangling": True})
 
 
-def compileOD(codeText: str, compile_args: list[str], timeout: int = 30) -> dict[str, object]:
+def compileOD(
+    codeText: str, compile_args: list[str], build_args: str = "Release", timeout: int = 30
+) -> dict[str, object]:
     """
     Create an OpenDream docker container to compile and run arbitrary code.
     Returns A dictionary containing the compiler and server logs.
@@ -50,7 +53,7 @@ def compileOD(codeText: str, compile_args: list[str], timeout: int = 30) -> dict
     timeout: Maximum duration a container is allowed to run for
     """
     try:
-        updateBuildImage()
+        updateBuildImage(build_Config=build_args)
     except BuildError as e:
         results = {"build_error": True, "exception": str(e)}
         return results

--- a/tests/docker_actions/test_docker.py
+++ b/tests/docker_actions/test_docker.py
@@ -11,7 +11,7 @@ def test_standard_compile(build_dir):
     code = 'world.log << "Hello, pytest!"'
 
     chdir(build_dir)
-    test_output = compileOD(codeText=code, compile_args=[""], build_args="Release", timeout=30)
+    test_output = compileOD(codeText=code, compile_args=[""], build_config="Release", timeout=30)
     assert test_output.keys() >= {"compiler", "server", "timeout"}
 
 
@@ -26,7 +26,7 @@ def test_complex_compile(build_dir):
 """
 
     chdir(build_dir)
-    test_output = compileOD(codeText=code, compile_args=[""], build_args="Release", timeout=30)
+    test_output = compileOD(codeText=code, compile_args=[""], build_config="Release", timeout=30)
     assert test_output.keys() >= {"compiler", "server", "timeout"}
 
 
@@ -38,7 +38,7 @@ def test_build_error(build_dir, mocker):
     code = 'world.log << "Hello, pytest!"'
 
     chdir(build_dir)
-    test_output = compileOD(codeText=code, compile_args=[""], build_args="Release", timeout=30)
+    test_output = compileOD(codeText=code, compile_args=[""], build_config="Release", timeout=30)
     assert "build_error" in test_output.keys()
 
 
@@ -47,7 +47,7 @@ def test_compile_timeout(build_dir):
     code = 'world.log << "Sleeping"\nsleep(500)'
 
     chdir(build_dir)
-    test_output = compileOD(codeText=code, compile_args=[""], build_args="Release", timeout=5)
+    test_output = compileOD(codeText=code, compile_args=[""], build_config="Release", timeout=5)
     assert test_output["timeout"] is True
 
 
@@ -58,6 +58,6 @@ def test_compile_bad_logs(build_dir, mocker):
 
     chdir(build_dir)
     code = 'world.log << "Hello, pytest!"'
-    test_output = compileOD(codeText=code, compile_args=[""], build_args="Release", timeout=30)
+    test_output = compileOD(codeText=code, compile_args=[""], build_config="Release", timeout=30)
 
     assert "error" in test_output.keys()

--- a/tests/docker_actions/test_docker.py
+++ b/tests/docker_actions/test_docker.py
@@ -11,7 +11,7 @@ def test_standard_compile(build_dir):
     code = 'world.log << "Hello, pytest!"'
 
     chdir(build_dir)
-    test_output = compileOD(codeText=code, compile_args=[""], timeout=30)
+    test_output = compileOD(codeText=code, compile_args=[""], build_args="Release", timeout=30)
     assert test_output.keys() >= {"compiler", "server", "timeout"}
 
 
@@ -26,7 +26,7 @@ def test_complex_compile(build_dir):
 """
 
     chdir(build_dir)
-    test_output = compileOD(codeText=code, compile_args=[""], timeout=30)
+    test_output = compileOD(codeText=code, compile_args=[""], build_args="Release", timeout=30)
     assert test_output.keys() >= {"compiler", "server", "timeout"}
 
 
@@ -38,7 +38,7 @@ def test_build_error(build_dir, mocker):
     code = 'world.log << "Hello, pytest!"'
 
     chdir(build_dir)
-    test_output = compileOD(codeText=code, compile_args=[""], timeout=30)
+    test_output = compileOD(codeText=code, compile_args=[""], build_args="Release", timeout=30)
     assert "build_error" in test_output.keys()
 
 
@@ -47,7 +47,7 @@ def test_compile_timeout(build_dir):
     code = 'world.log << "Sleeping"\nsleep(500)'
 
     chdir(build_dir)
-    test_output = compileOD(codeText=code, compile_args=[""], timeout=5)
+    test_output = compileOD(codeText=code, compile_args=[""], build_args="Release", timeout=5)
     assert test_output["timeout"] is True
 
 
@@ -58,6 +58,6 @@ def test_compile_bad_logs(build_dir, mocker):
 
     chdir(build_dir)
     code = 'world.log << "Hello, pytest!"'
-    test_output = compileOD(codeText=code, compile_args=[""], timeout=30)
+    test_output = compileOD(codeText=code, compile_args=[""], build_args="Release", timeout=30)
 
     assert "error" in test_output.keys()


### PR DESCRIPTION
This adds the framework for dotnet build arguments. For now, I'm limiting this just to the build configurations (Release v Debug).  **By default, images will be made using the `Release` configuration.**

Posting a request with `build_config` and a valid build configuration will force the Docker image to build OD using the requested configuration. For example...

Input:
```json
{
	"code_to_compile": "world.log << \"Hello, GitHub!\"",
	"build_config": "Debug"
}
```
Output:
```py
[COMPILER] [2023-10-15 20:55:47] [DEBUG] Request incoming containing: {'code_to_compile': 'world.log << "Hello, GitHub!"', 'build_config': 'Debug'}
```
```json
{
	"compiler": "\nCompiling test.dme on 514.1584\nWarning OD0000 at <internal>: This compiler was compiled in the Debug .NET configuration. This will impact compile speed.\nCompilation succeeded with 1 warnings\nSaved to test.json\nTotal time: 00:00\n",
	"server": "<--SNIP--> -------ODC-Start-------\n[INFO] world.log: Hello, GitHub!\n[INFO] world.log: --------ODC-End--------\n"
}
```


**Note**: this does increase the time it takes to get a return as it wont be able to utilize the previous build context and will have to regenerate the image _mostly_ from scratch.