### PR TITLE
Adds a new /version route

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "od-compiler"
-version = "0.3.0"
+version = "0.3.1"
 description = "OpenDream compiler listener"
 authors = ["Crossedfall <ping@crossedfall.io>"]
 maintainers = ["Crossedfall <ping@crossedfall.io>"]

--- a/src/od_compiler/__init__.py
+++ b/src/od_compiler/__init__.py
@@ -1,3 +1,5 @@
+from importlib.metadata import version
+
 from flask import abort
 from flask import Blueprint
 from flask import Flask
@@ -6,6 +8,8 @@ from flask import request
 from flask import Response
 from od_compiler.util.compiler_logger import compile_logger
 from od_compiler.util.docker_actions import compileOD
+
+__version__ = version("od-compiler")
 
 compile = Blueprint("compile", __name__, url_prefix="/")
 
@@ -36,3 +40,11 @@ def startCompile() -> Response:
     else:
         compile_logger.warning(f"Bad request received:\n{request.get_json()}")
         return abort(400)
+
+
+@compile.route("/version", methods=["GET"])
+def getVersion() -> Response:
+    """
+    Returns the current version of the compiler server
+    """
+    return jsonify(__version__)

--- a/src/od_compiler/__init__.py
+++ b/src/od_compiler/__init__.py
@@ -47,4 +47,4 @@ def getVersion() -> Response:
     """
     Returns the current version of the compiler server
     """
-    return jsonify(__version__)
+    return jsonify({"version": __version__})  # Could expand this to give the revisions from OD


### PR DESCRIPTION
Adds versioning into the app, mostly so I can version lock features in the Redbot cog but also for future build tooling if needed.

This PR also bumps the current version to 0.3.1... I was a bit premature in my prior release, so this is happening shortly after 0.3.0.

![image](https://github.com/OpenDreamProject/od-compiler-bot/assets/26130695/68fbb461-74c7-4ce2-98d8-853e7976326f)
